### PR TITLE
Fix talks page

### DIFF
--- a/internal/templates/base.html
+++ b/internal/templates/base.html
@@ -130,13 +130,13 @@
                 <h6 class="mb-4 flex justify-center font-semibold uppercase md:justify-start">
                   Pages
                 </h6>
-                <p class="mb-4">
+                <p class="mb-1">
                   <a href="/">Home</a>
                 </p>
-                <p class="mb-4">
+                <p class="mb-1">
                   <a href="/blogs">Blogs</a>
                 </p>
-                <p class="mb-4">
+                <p class="mb-1">
                   <a href="/talks">Talks</a>
                 </p>
               </div>

--- a/internal/templates/talks.html
+++ b/internal/templates/talks.html
@@ -4,7 +4,7 @@
 {% block description %}"Husni Naufal Zuhdi Talks"{% endblock %}
 
 {% block content %}
-<h1 class="mb-4 font-semibold uppercase md:justify-start">Blogs</h1>
+<h1 class="mb-4 font-semibold uppercase md:justify-start">Talks</h1>
 <hr>
     <h2 class="mb-2 hover:font-bold md:justify-start">
         <p>2022-07-02 | Cloud Computing 101 at UIN Syarif Hidayatullah Jakarta.</p>
@@ -13,10 +13,10 @@
         <p>2024-03-09 | How to setup simple Kubernetes cluster with GCE at <a href="https://www.linkedin.com/company/devops-jogja" target="_blank">DevOps Jogja</a>.</p>
     </h2>
     <h2 class="mb-2 hover:font-bold md:justify-start">
-        <p>2024-05-24 | Explore CI/CD with Github Action part #1 at <a href="https://www.linkedin.com/company/devops-jogja" target="_blank">DevOps Jogja</a>.</p>
+        <p>2024-05-24 | <a href="https://youtu.be/nhEOm4O-V98?si=TlOtBSbVFyy9AxQr" target="_blank">Explore CI/CD with Github Action part #1</a> at <a href="https://www.linkedin.com/company/devops-jogja" target="_blank">DevOps Jogja</a>.</p>
     </h2>
     <h2 class="mb-2 hover:font-bold md:justify-start">
-        <p>2024-06-07 | Explore CI/CD with Github Action part #2 at <a href="https://www.linkedin.com/company/devops-jogja" target="_blank">DevOps Jogja</a>.</p>
+        <p>2024-06-07 | <a href="https://youtu.be/13U4BudCPCk?si=skbdyjdKaXamO60O" target="_blank">Explore CI/CD with Github Action part #2</a> at <a href="https://www.linkedin.com/company/devops-jogja" target="_blank">DevOps Jogja</a>.</p>
     </h2>
 
 {% endblock content %}

--- a/statics/styles.css
+++ b/statics/styles.css
@@ -761,6 +761,10 @@ td {
   margin-right: 1.5rem;
 }
 
+.mb-1 {
+  margin-bottom: 0.25rem;
+}
+
 .mb-2 {
   margin-bottom: 0.5rem;
 }


### PR DESCRIPTION
Previously `/talks` page showed Blogs as the title. This PR fixes this bug.
Other thing is we reduce margin of the footer pages list.